### PR TITLE
Leave git repo and script

### DIFF
--- a/swarm-setup.sh
+++ b/swarm-setup.sh
@@ -101,11 +101,6 @@ sudo gcloud components update -q
 # Configure the Swarm service to start when the instance boots
 sudo update-rc.d swarm defaults
 
-# Remove the Git repository
-rm -fr CPO200-Google-Container-Registry
-
-# Remove this script
-rm swarm-setup.sh
 
 echo 'Finished with installation script'
 


### PR DESCRIPTION
The original script removes the local git clone of the repository and removes the swarm-setup.sh script. 

This prevents students from analyzing the script.
